### PR TITLE
Announcements bot integration

### DIFF
--- a/schemas/Announcement.js
+++ b/schemas/Announcement.js
@@ -35,13 +35,13 @@ export default {
             maxLength: 4096,
             validation: Rule => Rule.required()
         },
-				{
-						title: 'Is posted',
-						description: 'Determine whether announcement was sent out',
-						name: 'isPosted',
-						type: 'boolean',
-						initialValue: false
-				},
+	{
+	    title: 'Is posted',
+	    description: 'Determine whether announcement was sent out',
+	    name: 'isPosted',
+	    type: 'boolean',
+	    initialValue: false
+	},
         {
             title: 'Instance',
             name: 'instance',

--- a/schemas/Announcement.js
+++ b/schemas/Announcement.js
@@ -1,0 +1,53 @@
+import {
+    MdMail,
+} from "react-icons/md"
+
+export default {
+    title: 'Announcement',
+    name: 'announcement',
+    icon: MdMail,
+    type: 'document',
+    fields: [
+        {
+            title: 'Title',
+            name: 'title',
+            type: 'string',
+            validation: Rule => Rule.required()
+        },
+        {
+            title: 'Announcement date and time',
+            description: 'Date and time schedule of when to send the announcement out',
+            name: 'time',
+            type: 'datetime',
+            validation: Rule => Rule.required()
+        },
+        {
+            title: 'Link URL',
+            description: 'URL the announcement will point to (Cygnet page, event...)',
+            name: 'link',
+            type: 'url'
+        },
+        {
+            title: 'Text',
+            description: 'Announcement body text',
+            name: 'text',
+            type: 'text',
+            maxLength: 4096,
+            validation: Rule => Rule.required()
+        },
+				{
+						title: 'Is posted',
+						description: 'Determine whether announcement was sent out',
+						name: 'isPosted',
+						type: 'boolean',
+						initialValue: false
+				},
+        {
+            title: 'Instance',
+            name: 'instance',
+            type: 'reference',
+            validation: Rule => Rule.required(),
+            to: [{ type: 'instance' }]
+        },
+    ]
+}

--- a/schemas/Instance.js
+++ b/schemas/Instance.js
@@ -34,6 +34,13 @@ export default {
             hidden: ({ document }) => document?.connection == 'slack'
         },
         {
+            title: 'Discord Announcement Channel ID',
+            description: 'ID of Discord channel to post announcements to',
+            name: 'discordAnnouncementChannelId',
+            type: 'string',
+            hidden: ({ document }) => document?.connection == 'slack'
+        },
+        {
             title: 'Slack Workspace ID',
             description: 'Read-only configuration value',
             name: 'slackWorkspaceId',

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -18,6 +18,7 @@ import vote from './Vote.js'
 import result from './Result.js'
 import general from './General.js'
 import instance from './Instance.js'
+import announcement from './Announcement.js'
 
 
 // Then we give our schema to the builder and provide the result to Sanity
@@ -27,6 +28,6 @@ export default createSchema({
   // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
-    result, voteAllocation, vote, cycle, proposal, resource, user, simpleEditor, contentEditor, embedBlock, videoBlock, audioBlock, general, instance
+    result, voteAllocation, vote, cycle, proposal, resource, user, simpleEditor, contentEditor, embedBlock, videoBlock, audioBlock, general, instance, announcement
   ]),
 })


### PR DESCRIPTION
Add document to integrate with [announcements bot](https://github.com/Container-Technology/cygnet-announcements-bot) message fields  + an announcement channel field to the Instance schema.