### PR TITLE
Fix validation syntax + add recipient roles and recipient channel fields for announcements

### DIFF
--- a/deskStructure.js
+++ b/deskStructure.js
@@ -9,7 +9,8 @@ import {
     MdThumbUp,
     MdStar,
     MdGavel,
-    MdCircle
+    MdCircle,
+    MdMail
 } from "react-icons/md"
 
 export default () =>
@@ -218,5 +219,38 @@ export default () =>
                                 .filter('_type == "result" && instance._ref == $instanceId')
                                 .params({ instanceId })
                         )
+                ),
+            S.listItem()
+                .title('Announcements')
+                .icon(MdMail)
+                .child(
+                    S.list()
+                        .title("Announcements")
+                        .items([
+                            S.listItem()
+                                .title('All announcements')
+                                .icon(MdMail)
+                                .child(
+                                    S.documentList()
+                                        .title('Announcements')
+                                        .defaultLayout('detail')
+                                        .filter('_type == $type')
+                                        .params({ type: 'announcement' })
+                                ),
+                            S.listItem()
+                                .title('Announcements by instance')
+                                .icon(MdCircle)
+                                .child(
+                                    S.documentTypeList('instance')
+                                        .title('Announcmeents by instance')
+                                        .child(instanceId =>
+                                            S.documentList()
+                                                .title('Announcements')
+                                                .defaultLayout('detail')
+                                                .filter('_type == "announcement" && $instanceId == instance._ref')
+                                                .params({ instanceId })
+                                        )
+                                ),
+                        ])
                 ),
         ]);

--- a/schemas/Announcement.js
+++ b/schemas/Announcement.js
@@ -34,40 +34,40 @@ export default {
             name: 'text',
             type: 'text',
             validation: Rule => Rule.required().max(4000)
-	},
-	{
-	    title: 'Recipient roles',
+        },
+        {
+            title: 'Recipient roles',
             description: 'Discord roles which will receive the announcement',
-	    name: 'recipient_roles',
-	    type: 'array',
-	    of: [{ type: 'string' }],
-	    options: {
-	        layout: 'tags'
-	    }
-	},
-	{
-	    title: 'Recipient channels',
+            name: 'recipient_roles',
+            type: 'array',
+            of: [{ type: 'string' }],
+            options: {
+                layout: 'tags'
+            }
+        },
+        {
+            title: 'Recipient channels',
             description: 'Discord guild channels the announcement gets posted to',
-	    name: 'recipient_channels',
-	    type: 'array',
-	    of: [{ type: 'string' }],
-	    options: {
-	        layout: 'tags'
-	    }
-	},
-	{
-	    title: 'Is posted',
-	    description: 'Determine whether announcement was sent out',
-	    name: 'isPosted',
-	    type: 'boolean',
-	    initialValue: false
-	},
-	{
-	    title: 'Instance',
-	    name: 'instance',
-	    type: 'reference',
-	    validation: Rule => Rule.required(),
-	    to: [{ type: 'instance' }]
-	},
+            name: 'recipient_channels',
+            type: 'array',
+            of: [{ type: 'string' }],
+            options: {
+                layout: 'tags'
+            }
+        },
+        {
+            title: 'Is posted',
+            description: 'Determine whether announcement was sent out',
+            name: 'isPosted',
+            type: 'boolean',
+            initialValue: false
+        },
+        {
+            title: 'Instance',
+            name: 'instance',
+            type: 'reference',
+            validation: Rule => Rule.required(),
+            to: [{ type: 'instance' }]
+        },
     ]
 }

--- a/schemas/Announcement.js
+++ b/schemas/Announcement.js
@@ -37,13 +37,23 @@ export default {
 	},
 	{
 	    title: 'Recipient roles',
+            description: 'Discord roles which will receive the announcement',
 	    name: 'recipient_roles',
 	    type: 'array',
 	    of: [{ type: 'string' }],
 	    options: {
 	        layout: 'tags'
-	    },
-	    validation: Rule => Rule.required()
+	    }
+	},
+	{
+	    title: 'Recipient channels',
+            description: 'Discord guild channels the announcement gets posted to',
+	    name: 'recipient_channels',
+	    type: 'array',
+	    of: [{ type: 'string' }],
+	    options: {
+	        layout: 'tags'
+	    }
 	},
 	{
 	    title: 'Is posted',

--- a/schemas/Announcement.js
+++ b/schemas/Announcement.js
@@ -25,16 +25,26 @@ export default {
             title: 'Link URL',
             description: 'URL the announcement will point to (Cygnet page, event...)',
             name: 'link',
-            type: 'url'
+            type: 'url',
+            validation: Rule => Rule.max(256)
         },
         {
             title: 'Text',
             description: 'Announcement body text',
             name: 'text',
             type: 'text',
-            maxLength: 4096,
-            validation: Rule => Rule.required()
-        },
+            validation: Rule => Rule.required().max(4000)
+	},
+	{
+	    title: 'Recipient roles',
+	    name: 'recipient_roles',
+	    type: 'array',
+	    of: [{ type: 'string' }],
+	    options: {
+	        layout: 'tags'
+	    },
+	    validation: Rule => Rule.required()
+	},
 	{
 	    title: 'Is posted',
 	    description: 'Determine whether announcement was sent out',
@@ -42,12 +52,12 @@ export default {
 	    type: 'boolean',
 	    initialValue: false
 	},
-        {
-            title: 'Instance',
-            name: 'instance',
-            type: 'reference',
-            validation: Rule => Rule.required(),
-            to: [{ type: 'instance' }]
-        },
+	{
+	    title: 'Instance',
+	    name: 'instance',
+	    type: 'reference',
+	    validation: Rule => Rule.required(),
+	    to: [{ type: 'instance' }]
+	},
     ]
 }

--- a/schemas/Instance.js
+++ b/schemas/Instance.js
@@ -34,13 +34,6 @@ export default {
             hidden: ({ document }) => document?.connection == 'slack'
         },
         {
-            title: 'Discord Announcement Channel ID',
-            description: 'ID of Discord channel to post announcements to',
-            name: 'discordAnnouncementChannelId',
-            type: 'string',
-            hidden: ({ document }) => document?.connection == 'slack'
-        },
-        {
             title: 'Slack Workspace ID',
             description: 'Read-only configuration value',
             name: 'slackWorkspaceId',


### PR DESCRIPTION
Fixes validation typos for announcement schema and adds field for routing messages by Discord roles.
Also moving announcement channel from Instance config to per-announcement setting to enable audience segmentation within single guild.